### PR TITLE
updated CircleCI config for dependency install (#131)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            {% if parameters.version in ['7', '8', '9'] %}
+            {% if parameters.version in ['7', '8', '9', '10'] %}
               npm ci
             {% else %}
               npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,12 @@ jobs:
             echo "node: $(node --version)"
       - run:
           name: Install dependencies
-          command: npm install
+          command: |
+            {% if parameters.version in ['7', '8', '9'] %}
+              npm ci
+            {% else %}
+              npm install
+            {% endif %}
       - run:
           name: Install typescript
           command: |


### PR DESCRIPTION
Updated the Install Dependency step with conditional to run **`npm ci`** for Node 7 and above, else it'll use the legacy **`npm install`** for Node 4, 5, and 6.