### PR TITLE
Ci workflow update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ workflows:
           name: node-latest
           version: "latest"
           requires:
-            - node13
+            - node14
 
 jobs:
   unit-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,38 @@ workflows:
   node-tests:
     jobs:
       - unit-tests:
+          name: node4
+          version: "4"
+      - unit-tests:
+          name: node6
+          version: "6"
+          requires:
+            - node4
+      - unit-tests:
+          name: node7
+          version: "7"
+          requires:
+            - node6
+      - unit-tests:
+          name: node8
+          version: "8"
+          requires:
+            - node7
+      - unit-tests:
           name: node9
           version: "9"
+          requires:
+            - node8
       - unit-tests:
           name: node10
           version: "10"
           requires:
             - node9
+      - unit-tests:
+          name: node13
+          version: "13"
+          requires:
+            - node10
       - unit-tests:
           name: node-latest
           version: "latest"
@@ -32,7 +57,7 @@ jobs:
             echo "node: $(node --version)"
       - when:
           condition:
-            matches: { pattern: "(4|6|7)", value: << parameters.version >> }
+            matches: { pattern: "^4$|^5$|^6$|^7$|^9$", value: << parameters.version >> }
           steps:
             - run:
                 name: Install dependencies - legacy mode
@@ -40,7 +65,7 @@ jobs:
       - when:
           condition:
             not:
-              matches: { pattern: "(4|6|7)", value: << parameters.version >> }
+              matches: { pattern: "^4$|^5$|^6$|^7$|^9$", value: << parameters.version >> }
           steps:
             - run:
                 name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,15 +32,20 @@ workflows:
           requires:
             - node9
       - unit-tests:
-          name: node13
-          version: "13"
+          name: node12
+          version: "12"
           requires:
             - node10
+      - unit-tests:
+          name: node14
+          version: "14"
+          requires:
+            - node12
       - unit-tests:
           name: node-latest
           version: "latest"
           requires:
-            - node10
+            - node13
 
 jobs:
   unit-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,28 +4,8 @@ workflows:
   node-tests:
     jobs:
       - unit-tests:
-          name: node4
-          version: "4"
-      - unit-tests:
-          name: node6
-          version: "6"
-          requires:
-            - node4
-      - unit-tests:
-          name: node7
-          version: "7"
-          requires:
-            - node6
-      - unit-tests:
-          name: node8
-          version: "8"
-          requires:
-            - node7
-      - unit-tests:
           name: node9
           version: "9"
-          requires:
-            - node8
       - unit-tests:
           name: node10
           version: "10"
@@ -50,9 +30,21 @@ jobs:
           name: Node Version
           command: |
             echo "node: $(node --version)"
-      - run:
-          name: Install dependencies
-          command: npm install
+      - when:
+          condition:
+            matches: { pattern: "(4|6|7)", value: << parameters.version >> }
+          steps:
+            - run:
+                name: Install dependencies - legacy mode
+                command: npm install
+      - when:
+          condition:
+            not:
+              matches: { pattern: "(4|6|7)", value: << parameters.version >> }
+          steps:
+            - run:
+                name: Install dependencies
+                command: npm ci
       - run:
           name: Install typescript
           command: |


### PR DESCRIPTION
Update workflow to use `npm ci` instead of `npm install` on circleCI runs. 

New command is not available on older node versions: https://nodejs.org/en/download/releases

npm ci requires npm version 5.7.1 at least.