### PR TITLE
chore: use release-please to automate versioning, changelogs and GitHub releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,23 @@
+# Automate generation of release PRs using Conventional Commits
+# This workflow will create a release PR when a branch is merged into master,
+# reading the conventional commit message to determine the next semantic version 
+# for the package. This commit data is also used to generate a changelog for the release.
+# See:
+# - https://github.com/googleapis/release-please
+# - https://www.conventionalcommits.org/en/v1.0.0/
+on:
+  push:
+    branches:
+      - master
+
+name: release-please
+jobs:
+  release-please:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: node
+          # See https://github.com/googleapis/release-please-action#github-credentials
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
Using this action, as long as contributors follow the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/) new versions, releases and changelog updates can be automated. This action can also be extended to [automate npm publishing](https://github.com/googleapis/release-please-action#automating-publication-to-npm) on version-up. For maintainers, this reduces a lot of overhead in the "admin" of new releases, and for consumers, it increases clarity on new changes. Note that for the PRs created by release-please to be able to trigger further GitHub actions, a `token` will need to be provided. In this case, I've pointed to a secret called `RELEASE_PLEASE_TOKEN`. See https://github.com/googleapis/release-please-action#github-credentials for more information on this.